### PR TITLE
fix: deploy develop branch on docker hub workflow

### DIFF
--- a/.github/workflows/docker-publish-develop.yml
+++ b/.github/workflows/docker-publish-develop.yml
@@ -1,0 +1,79 @@
+name: Docker Publish
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+
+env:
+  tag: develop
+  project: sonarr-sma
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          -
+            dockerfile: Dockerfile
+            platform: amd64
+          -
+            dockerfile: Dockerfile.armhf
+            platform: armhf
+          -
+            dockerfile: Dockerfile.arm64
+            platform: arm64
+    steps:
+      -
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.platform }}
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }}-${{ matrix.platform }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - 
+        name: Create manifests for DockerHub
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        run: |
+          docker manifest create \
+          ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }} \
+          --amend ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }}-amd64 \
+          --amend ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }}-armhf \
+          --amend ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }}-arm64
+      -
+        name: Push manifest to DockerHub
+        run: |
+          docker manifest push ${{ secrets.DOCKER_USERNAME }}/${{ env.project }}:${{ env.tag }}

--- a/.github/workflows/docker-publish-develop.yml
+++ b/.github/workflows/docker-publish-develop.yml
@@ -1,4 +1,4 @@
-name: Docker Publish
+name: Docker Publish Develop Branch
 
 on:
   schedule:


### PR DESCRIPTION
### Bug

- Develop branch workflow isn't publishing on the docker hub as it should (it defined at every day at 5).

This is because:

> Schedule works on the master(default) branch, if you put it in the other branch yaml, it won’t be triggered.

More information [here](https://github.community/t/on-schedule-per-branch/17525)

### Fix 

- Added a workflow with the schedule defined in the master branch and checkout on develop branch.

### Links
- https://github.community/t/on-schedule-per-branch/17525
- https://stackoverflow.com/questions/58798886/github-actions-schedule-operation-on-branch