### PR TITLE
Use linuxserver/ffmpeg as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY --from=ffmpeg / /
 ENV SMA_PATH /usr/local/sma
 ENV SMA_RS Sonarr
 ENV SMA_UPDATE false
-ENV SMA_FFMPEG_URL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
 
 RUN \
   # get git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,27 @@
-FROM ghcr.io/linuxserver/sonarr
+FROM ghcr.io/linuxserver/ffmpeg AS ffmpeg
+
+FROM ghcr.io/linuxserver/sonarr AS sonarr
+
 LABEL maintainer="mdhiggins <mdhiggins23@gmail.com>"
+
+# copy ffmpeg executable from linuxserver
+COPY --from=ffmpeg / /
 
 ENV SMA_PATH /usr/local/sma
 ENV SMA_RS Sonarr
 ENV SMA_UPDATE false
 ENV SMA_FFMPEG_URL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
 
-# get python3 and git, and install python libraries
 RUN \
+  # get git
   apt-get update && \
-  apt-get install -y \
-    git \
-    wget \
-    python3 \
-    python3-pip && \
-# make directory
+  apt-get install -y git && \
+  # make directory
   mkdir ${SMA_PATH} && \
-# download repo
+  # download repo
   git config --global --add safe.directory ${SMA_PATH} && \
   git clone https://github.com/mdhiggins/sickbeard_mp4_automator.git ${SMA_PATH} && \
-# install pip, venv, and set up a virtual self contained python environment
-  python3 -m pip install --user --upgrade pip && \
-  python3 -m pip install --user virtualenv && \
-  python3 -m virtualenv ${SMA_PATH}/venv && \
-  ${SMA_PATH}/venv/bin/pip install -r ${SMA_PATH}/setup/requirements.txt && \
-# ffmpeg (disabled for now)
-#  wget ${SMA_FFMPEG_URL} -O /tmp/ffmpeg.tar.xz && \
-#  tar -xJf /tmp/ffmpeg.tar.xz -C /usr/local/bin --strip-components 1 && \
-#  chgrp users /usr/local/bin/ffmpeg && \
-#  chgrp users /usr/local/bin/ffprobe && \
-#  chmod g+x /usr/local/bin/ffmpeg && \
-#  chmod g+x /usr/local/bin/ffprobe && \
-# cleanup
+  # cleanup
   apt-get purge --auto-remove -y && \
   apt-get clean && \
   rm -rf \

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Docker container for Sonarr that includes all FFMPEG and python requirements to 
 
 |Tag|Description|
 |---|---|
-|latest|Stable release from Sonarr with precompiled FFMPEG binaries|
-|build|Stable release from Sonarr with FFMPEG compiled from jrottenberg/ffmpeg|
+|latest|Stable release from linuxserver/sonarr with FFMPEG compiled from linuxserver/ffmpeg|
+|build|Stable release from linuxserver/sonarr with FFMPEG compiled from jrottenberg/ffmpeg|
 |develop|Develop release from Sonarr with precompiled FFMPEG binaries|
 
 ## Usage
@@ -78,56 +78,38 @@ Located at `/usr/local/sma/config/sma.log` inside the container and your mounted
 |HOST|Local IP address for callback requests, default `127.0.0.1`|
 |SMA_PATH|`/usr/local/sma`|
 |SMA_UPDATE|Default `false`. Set `true` to pull git update of SMA on restart|
-|SMA_FFMPEG_URL|Defaults to latest static build from https://johnvansickle.com but can override by changing this var|
+|SMA_FFMPEG_URL|If provided, override linuxserver/ffmpeg with a static build provided by the URL.|
 |SMA_STRIP_COMPONENTS|Default `1`. Number of components to strip from your tar.xz file when extracting so that FFmpeg binaries land in `/usr/local/bin`|
-|SMA_HWACCEL|Default `false`. Set `true` to pull additional packages used for hardare acceleration (will require custom FFmpeg binaries)|
-|SMA_USE_REPO|Default `false`. Set `true` to download FFMPEG binaries for default repository (will likely be older versions)|
 
-## Special Considerations
-Using the `build` tag leverages mulit-stage docker builds to generate FFMPEG compiled using [jrottenberg/ffmpeg's](https://hub.docker.com/r/jrottenberg/ffmpeg) containers. This allows flexibility with building FFMPEG using special options such as VAAPI or NVENC. Building locally allows `ARG` values to be set to change the underlying parent container tags as below. It is recommended that you match your Ubuntu version in the ffmpeg_tag and sonarr_tag to ensure no missing dependencies.
+## Hardware Acceleration
+The default image is built with [linuxserver/ffmpeg](https://hub.docker.com/r/linuxserver/ffmpeg), which supports VAAPI, QSV, and NVEnc/NVDec.
 
-|ARG|Default|Description|
-|---|---|---|
-|ffmpeg_tag|latest|Set tag to correspond to jrottenberg/ffmpeg:tag|
-|sonarr_tag|latest|Set tag to correspond to linuxserver/sonarr:tag|
-|extra_packages||Set additional packages/dependencies that might need to be installed via apt-get or apk, separated by spaces|
+For VAAPI/QSV, you need to mount the hardware device from `/dev/dri`. 
+
+Nvidia GPU support requires the `nvidia` runtime, available by installing [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit).
 
 ### VAAPI docker-compose sample
 ~~~yml
 services:
   sonarr:
     container_name: sonarr
-    build:
-      context: https://github.com/mdhiggins/sonarr-sma.git#build
-      args:
-        sonarr-tag: develop
-        ffmpeg_tag: 4.4-vaapi2004
     devices:
       - /dev/dri/renderD128:/dev/dri/renderD128
 ~~~
 
-For the newer Linuxserver Sonarr builds based on mono the jrottenberg FFMpeg builds are not compatible and will have issues with VAAPI. The repo build of FFMpeg however includes VAAPI with appropriate libaries so you can use non-build tags with the `SMA_USE_REPO` environment variable set to `true` to enable VAAPI supported FFMpeg builds
-
+### NVIDIA / NVEnc  NVDec docker-compose sample
 ~~~yml
 services:
   sonarr:
-    image: mdhiggins/sonarr-sma
     container_name: sonarr
-    volumes:
-      - /opt/appdata/sonarr:/config
-      - /opt/appdata/sma:/usr/local/sma/config
-      - /mnt/storage/tv:/tv
-      - /mnt/storage/downloads:/downloads
-    ports:
-      - 8989:8989
-    restart: always
-    environment:
-      - PUID=${PUID}
-      - PGID=${PGID}
-      - SMA_USE_REPO=true
-    devices:
-      - /dev/dri/renderD128:/dev/dri/renderD128
+    runtime: nvidia
 ~~~
 
-### NVIDIA / NVEnc
-Currently nVidia and NVEnc are not supported on mono which is used by the lastest Linuxserver containers. In order to use NVEnc or nVidia hardare accleration you will need to use an older tag that is still based on Ubuntu
+## Custom Builds
+Using the `build` tag leverages multi-stage docker builds to generate FFMPEG compiled using [jrottenberg/ffmpeg's](https://hub.docker.com/r/jrottenberg/ffmpeg) containers. This allows flexibility with building FFMPEG using special options such as VAAPI or NVENC (though these are now included by default in the default linuxserver/ffmpeg image). Building locally allows `ARG` values to be set to change the underlying parent container tags as below. It is recommended that you match your Ubuntu version in the ffmpeg_tag and sonarr_tag to ensure no missing dependencies.
+
+|ARG|Default|Description|
+|---|---|---|
+|ffmpeg_tag|latest|Set tag to correspond to jrottenberg/ffmpeg:tag|
+|sonarr_tag|latest|Set tag to correspond to linuxserver/sonarr:tag|
+|extra_packages||Set additional packages/dependencies that might need to be installed via apt-get or apk, separated by spaces|

--- a/root/etc/s6-overlay/s6-rc.d/init-sma-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-sma-config/run
@@ -20,20 +20,7 @@ if [ -f /usr/bin/apt ]; then
         python3-pip \
         python3-venv \
         fonts-dejavu \
-        git \
         ${SMA_EXTRA_PACKAGES} > /dev/null
-    if [[ "${SMA_HWACCEL}" == "true" ]]; then
-        apt-get install --no-install-recommends -y -qq \
-            libva-drm2 \
-            libva2 \
-            i965-va-driver \
-            intel-media-va-driver-non-free \
-            mesa-va-drivers > /dev/null
-    fi
-    if [[ "${SMA_USE_REPO}" == "true" ]]; then
-        apt-get install --no-install-recommends -y -qq \
-            ffmpeg > /dev/null
-    fi
 elif [ -f /sbin/apk ]; then
     # Alpine
     apk update > /dev/null
@@ -42,6 +29,7 @@ elif [ -f /sbin/apk ]; then
         xz \
         python3 \
         py3-pip \
+        fontconfig \
         ttf-dejavu \
         git \
         ${SMA_EXTRA_PACKAGES} > /dev/null
@@ -97,33 +85,8 @@ else
 fi
 
 # ffmpeg
-if [[ $(which ffmpeg) ]]; then
-    :
-elif [[ -n "${SMA_FFMPEG_PATH}" ]] && [[ -n "${SMA_FFPROBE_PATH}" ]]; then
-    :
-else
-    # check ffmpeg URL
-    if [[ -z "${SMA_FFMPEG_URL}" ]]; then
-    architecture=$(arch)
-    case "$architecture" in
-        'x86_64'|'amd64')
-        export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
-        ;;
-        'i386'|'i686')
-        export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz"
-        ;;
-        'arm'|'armv7l'|'armv6l')
-        export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armhf-static.tar.xz"
-        ;;
-        'aarch64_be'|'aarch64'|'armv8b'|'armv8l'|'arm64')
-        export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz"
-        ;;
-        *)
-        export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-$architecture-static.tar.xz"
-        ;;
-    esac
+if [[ -v "${SMA_FFMPEG_URL}" ]]; then
     echo "[90-sma-config] Set FFMPEG URL to ${SMA_FFMPEG_URL}"
-    fi
     echo "[90-sma-config] Downloading and installing FFMpeg from ${SMA_FFMPEG_URL}"
     wget -q ${SMA_FFMPEG_URL} -O /tmp/ffmpeg.tar.xz
     tar --exclude='*.html' --exclude='*.txt' -xJf /tmp/ffmpeg.tar.xz -C /usr/local/bin --strip-components ${SMA_STRIP_COMPONENTS}

--- a/root/etc/s6-overlay/s6-rc.d/init-sma-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-sma-config/run
@@ -19,7 +19,6 @@ if [ -f /usr/bin/apt ]; then
         python3 \
         python3-pip \
         python3-venv \
-        fontconfig \
         fonts-dejavu \
         git \
         ${SMA_EXTRA_PACKAGES} > /dev/null
@@ -43,7 +42,6 @@ elif [ -f /sbin/apk ]; then
         xz \
         python3 \
         py3-pip \
-        fontconfig \
         ttf-dejavu \
         git \
         ${SMA_EXTRA_PACKAGES} > /dev/null


### PR DESCRIPTION
As discussed in #49.

Tried to make as few changes as possible to the existing environment variables so that this doesn't break user's setups.

- Left the `SMA_FFMPEG_URL` option in place for anyone who was utilizing it. You'll still have all the environment variables and junk from the `linuxserver/ffmpeg` image, but if for some reason you want a specific binary you can do that.
- Removed `SMA_USE_REPO` as this no longer makes much sense.
- Removed some `apt` lines and `venv` setup from the Dockerfile as it seems like this is covered by s6.
- Removed `SMA_HWACCEL` as hardware acceleration libs are included in the ffmpeg container
- Removed `fontconfig` from the r6 package installations since it is built from source in the ffmpeg container

This change now leaves `build` and `develop` in a slightly weird place. `linuxserver/sonarr:develop` is built on Alpine instead of Jammy (no discussion in their repo about consolidating the two). I haven't tried layering the images but I imagine there will be issues there. 

`build` now has a slight divergence in config options. `SMA_HWACCEL` is no longer needed, but some might be relying on it to install libraries required by their custom ffmpeg binaries.

My vote would be to deprecate `SMA_HWACCEL` from `build` and have people use the "hidden" `SMA_EXTRA_PACKAGES` instead. Then, they can specify which image they want to compile from: `jrottenberg/ffmpeg` or `linuxserver/ffmpeg` using `ffmpeg_source`/`ffmpeg_tag`, and install any extra packages they need using that var. 
