### PR TITLE
Mark init-sma-config as dependency to sonarr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,4 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
+RUN chmod +x ${SMA_PATH}/postSonarr.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,3 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
-RUN chmod +x ${SMA_PATH}/postSonarr.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -39,3 +39,4 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
+RUN chmod +x ${SMA_PATH}/postSonarr.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -39,4 +39,3 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
-RUN chmod +x ${SMA_PATH}/postSonarr.sh


### PR DESCRIPTION
This fixes a race condition on container rebuild when there are pending imports

The issue:
* A sonarr instance with pending imports is shutdown and rebuilt
* init-sma-config runs on container up and starts downloading ffmpeg (this can take up to a minute or so)
* sonarr launches immediately, tries to import pending media and fails as init-sma-config is working and has not yet set permissions
* init-sma-config finally finishes, setting permissions of the `.sh` script

Marking init-sma-config as a dependency fixes this issue at the expense of taking slightly longer for the sonarr service to boot and show it's web interface. This is worth avoiding the race condition and not failing pending imports on rebuild IMHO.